### PR TITLE
Simplify orb into a one-step orb

### DIFF
--- a/src/git/orb.yml
+++ b/src/git/orb.yml
@@ -11,7 +11,7 @@ commands:
         type: string
     steps:
       - run:
-          name: Set up HOME environment variable
+          name: Git Checkout
           command: |
             # Workaround old docker images with incorrect $HOME
             # check https://github.com/docker/docker/issues/2968 for details
@@ -19,9 +19,8 @@ commands:
             then
               export HOME=$(getent passwd $(id -un) | cut -d: -f6)
             fi
-      - run:
-          name: Set up SSH access
-          command: |
+          
+            # Set up SSH access
             mkdir -p ~/.ssh
 
             echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==
@@ -31,15 +30,13 @@ commands:
             (umask 077; touch ~/.ssh/id_rsa)
             chmod 0600 ~/.ssh/id_rsa
             (cat $CHECKOUT_KEY > ~/.ssh/id_rsa)
-      - run:
-          name: Set up git configuration
-          command: |
+      
+            # Set up git configuration
             # use git+ssh instead of https
             git config --global url."ssh://git@github.com".insteadOf "https://github.com" || true
             git config --global gc.auto 0 || true
-      - run:
-          name: Set up git repository
-          command: |
+            
+            # Set up git repository
             if [ -e << parameters.repo_path >>/.git ]
             then
               cd << parameters.repo_path >>
@@ -49,18 +46,16 @@ commands:
               cd << parameters.repo_path >>
               git clone --depth 1 "$CIRCLE_REPOSITORY_URL" .
             fi
-      - run:
-          name: Fetch git origin remote
-          command: |
+            
+            # Fetch git origin remote
             if [ -n "$CIRCLE_TAG" ]
             then
               git fetch --depth 1 --force origin "refs/tags/$CIRCLE_TAG"
             else
               git fetch --depth 5 --force origin "$CIRCLE_BRANCH:remotes/origin/$CIRCLE_BRANCH"
             fi
-      - run:
-          name: Checkout branch
-          command: |
+      
+            # Checkout branch
             if [ -n "$CIRCLE_TAG" ]
             then
               git reset --hard "$CIRCLE_SHA1"


### PR DESCRIPTION
Make it a one step orb, this prevents cluttering the job outputs, which confuses developers.